### PR TITLE
Add support for requiring flexible itineraries in itinerary filtering

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ItineraryFiltersInputType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/plan/ItineraryFiltersInputType.java
@@ -26,6 +26,7 @@ public class ItineraryFiltersInputType {
     "groupedOtherThanSameLegsMaxCostMultiplier";
   private static final String GROUP_SIMILARITY_KEEP_N_ITINERARIES =
     "groupSimilarityKeepNumOfItineraries";
+  private static final String REQUIRE_FLEX_ITINERARIES = "requireFlexItineraries";
 
   public static GraphQLInputObjectType create(ItineraryFilterPreferences dft) {
     return GraphQLInputObjectType.newInputObject()
@@ -143,6 +144,16 @@ public class ItineraryFiltersInputType {
           .defaultValue(dft.debug())
           .build()
       )
+      .field(
+        GraphQLInputObjectField.newInputObjectField()
+          .type(Scalars.GraphQLBoolean)
+          .name(REQUIRE_FLEX_ITINERARIES)
+          .description(
+            "If true, remove itineraries that do not include any flexible legs."
+          )
+          .defaultValue(dft.requireFlexItineraries())
+          .build()
+      )
       .build();
   }
 
@@ -174,6 +185,7 @@ public class ItineraryFiltersInputType {
       )
     );
     setField(callWith, DEBUG, builder::withDebug);
+    setField(callWith, REQUIRE_FLEX_ITINERARIES, builder::withRequireFlexItineraries);
   }
 
   private static <T> void setField(

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryListFilterChainBuilder.java
@@ -35,6 +35,7 @@ import org.opentripplanner.routing.algorithm.filterchain.filters.transit.KeepIti
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.RemoveItinerariesWithShortStreetLeg;
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.RemoveTransitIfStreetOnlyIsBetter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.RemoveTransitIfWalkingIsBetter;
+import org.opentripplanner.routing.algorithm.filterchain.filters.transit.RemoveNonFlexItineraries;
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.TransitGeneralizedCostFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.group.RemoveIfFirstOrLastTripIsTheSame;
 import org.opentripplanner.routing.algorithm.filterchain.filters.transit.group.RemoveOtherThanSameLegsMaxGeneralizedCost;
@@ -93,6 +94,7 @@ public class ItineraryListFilterChainBuilder {
   private Cost generalizedCostMaxLimit = null;
   private boolean transitGroupPriorityUsed = false;
   private boolean filterDirectFlexBySearchWindow = true;
+  private boolean requireFlexItineraries = false;
 
   /**
    * Sandbox filters which decorate the itineraries with extra information.
@@ -385,6 +387,11 @@ public class ItineraryListFilterChainBuilder {
     return this;
   }
 
+  public ItineraryListFilterChainBuilder withRequireFlexItineraries(boolean require) {
+    this.requireFlexItineraries = require;
+    return this;
+  }
+
   public ItineraryListFilterChainBuilder withTransitAlerts(
     TransitAlertService transitAlertService,
     Function<Station, MultiModalStation> getMultiModalStation
@@ -463,6 +470,11 @@ public class ItineraryListFilterChainBuilder {
 
       if (removeWalkAllTheWayResults) {
         addRemoveFilter(filters, new RemoveWalkOnlyFilter());
+      }
+
+      // If requested, remove itineraries that do not include any flex legs
+      if (requireFlexItineraries) {
+        addRemoveFilter(filters, new RemoveNonFlexItineraries());
       }
 
       if (bikeRentalDistanceRatio > 0) {

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/RemoveNonFlexItineraries.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/transit/RemoveNonFlexItineraries.java
@@ -1,0 +1,22 @@
+package org.opentripplanner.routing.algorithm.filterchain.filters.transit;
+
+import java.util.function.Predicate;
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.model.plan.Leg;
+import org.opentripplanner.routing.algorithm.filterchain.framework.spi.RemoveItineraryFlagger;
+
+/**
+ * Remove itineraries that do not contain any flexible leg.
+ */
+public class RemoveNonFlexItineraries implements RemoveItineraryFlagger {
+
+	@Override
+	public String name() {
+		return "remove-non-flex-itineraries";
+	}
+
+	@Override
+	public Predicate<Itinerary> shouldBeFlaggedForRemoval() {
+		return itinerary -> itinerary.legs().stream().noneMatch(Leg::isFlexibleTrip);
+	}
+}

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/mapping/RouteRequestToFilterChainMapper.java
@@ -99,6 +99,7 @@ public class RouteRequestToFilterChainMapper {
       .withRemoveWalkAllTheWayResults(removeWalkAllTheWayResults)
       .withRemoveTransitIfWalkingIsBetter(true)
       .withFilterDirectFlexBySearchWindow(params.filterDirectFlexBySearchWindow())
+      .withRequireFlexItineraries(params.requireFlexItineraries())
       .withDebugEnabled(params.debug());
 
     if (!request.preferences().transit().relaxTransitGroupPriority().isNormal()) {

--- a/application/src/main/java/org/opentripplanner/routing/api/request/preference/ItineraryFilterPreferences.java
+++ b/application/src/main/java/org/opentripplanner/routing/api/request/preference/ItineraryFilterPreferences.java
@@ -32,6 +32,7 @@ public final class ItineraryFilterPreferences {
   private final TransitGeneralizedCostFilterParams transitGeneralizedCostLimit;
   private final CostLinearFunction removeTransitWithHigherCostThanBestOnStreetOnly;
   private final boolean filterDirectFlexBySearchWindow;
+  private final boolean requireFlexItineraries;
 
   private ItineraryFilterPreferences() {
     this.accessibilityScore = false;
@@ -54,6 +55,7 @@ public final class ItineraryFilterPreferences {
       1.3
     );
     this.filterDirectFlexBySearchWindow = true;
+    this.requireFlexItineraries = false;
   }
 
   private ItineraryFilterPreferences(Builder builder) {
@@ -78,6 +80,7 @@ public final class ItineraryFilterPreferences {
       builder.removeTransitWithHigherCostThanBestOnStreetOnly
     );
     this.filterDirectFlexBySearchWindow = builder.filterDirectFlexBySearchWindow;
+    this.requireFlexItineraries = builder.requireFlexItineraries;
   }
 
   public static Builder of() {
@@ -144,6 +147,10 @@ public final class ItineraryFilterPreferences {
     return filterDirectFlexBySearchWindow;
   }
 
+  public boolean requireFlexItineraries() {
+    return requireFlexItineraries;
+  }
+
   @Override
   public String toString() {
     return ToStringBuilder.of(ItineraryFilterPreferences.class)
@@ -191,6 +198,7 @@ public final class ItineraryFilterPreferences {
         removeItinerariesWithSameRoutesAndStops
       )
       .addBoolIfTrue("filterDirectFlexBySearchWindow", filterDirectFlexBySearchWindow)
+      .addBoolIfTrue("requireFlexItineraries", requireFlexItineraries)
       .toString();
   }
 
@@ -220,7 +228,8 @@ public final class ItineraryFilterPreferences {
         that.removeTransitWithHigherCostThanBestOnStreetOnly
       ) &&
       Objects.equals(transitGeneralizedCostLimit, that.transitGeneralizedCostLimit) &&
-      filterDirectFlexBySearchWindow == that.filterDirectFlexBySearchWindow
+      filterDirectFlexBySearchWindow == that.filterDirectFlexBySearchWindow &&
+      requireFlexItineraries == that.requireFlexItineraries
     );
   }
 
@@ -240,7 +249,8 @@ public final class ItineraryFilterPreferences {
       removeItinerariesWithSameRoutesAndStops,
       transitGeneralizedCostLimit,
       removeTransitWithHigherCostThanBestOnStreetOnly,
-      filterDirectFlexBySearchWindow
+      filterDirectFlexBySearchWindow,
+      requireFlexItineraries
     );
   }
 
@@ -261,6 +271,7 @@ public final class ItineraryFilterPreferences {
     private TransitGeneralizedCostFilterParams transitGeneralizedCostLimit;
     private CostLinearFunction removeTransitWithHigherCostThanBestOnStreetOnly;
     private boolean filterDirectFlexBySearchWindow;
+    private boolean requireFlexItineraries;
 
     public ItineraryFilterPreferences original() {
       return original;
@@ -364,6 +375,7 @@ public final class ItineraryFilterPreferences {
       this.removeTransitWithHigherCostThanBestOnStreetOnly =
         original.removeTransitWithHigherCostThanBestOnStreetOnly;
       this.filterDirectFlexBySearchWindow = original.filterDirectFlexBySearchWindow;
+      this.requireFlexItineraries = original.requireFlexItineraries;
     }
 
     public Builder apply(Consumer<Builder> body) {
@@ -378,6 +390,11 @@ public final class ItineraryFilterPreferences {
 
     public Builder withFilterDirectFlexBySearchWindow(boolean filterDirectFlexBySearchWindow) {
       this.filterDirectFlexBySearchWindow = filterDirectFlexBySearchWindow;
+      return this;
+    }
+
+    public Builder withRequireFlexItineraries(boolean requireFlexItineraries) {
+      this.requireFlexItineraries = requireFlexItineraries;
       return this;
     }
   }


### PR DESCRIPTION
This PR adds a itinerary filter that will only return trips that actually include a flexible leg. 